### PR TITLE
Remove jackson-jaxrs-json-provider as a maven dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,11 +123,6 @@
       <version>${jackson-version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>${jackson-version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-admin-client</artifactId>
       <version>${keycloak.version}</version>


### PR DESCRIPTION
Removing jackson-jaxrs-json-provider as a maven dependency as it still depends on javax.* classes where the java client already depends on jakarta.* classes

Fixes #15 